### PR TITLE
Fixing 500 issue with the yahoo-finance2 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Note that all symbols are based on those used by Yahoo Finance.
 ### Backend
 
 - **Next.js API Routes**: The backend logic is handled using Next.js API routes. This eliminates the need for a separate Express server.
-- **Yahoo Finance API**: We use the `yahoo-finance2` package to fetch historical stock data.
+- **Yahoo Finance API**: We use the `yahoo-finance2` package to fetch a stock's chart data and convert it to historical data. See https://github.com/gadicc/node-yahoo-finance2/issues/795
 
 ## Technical Architecture
 

--- a/app/src/app/api/seasonality/route.ts
+++ b/app/src/app/api/seasonality/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import yahooFinance from "yahoo-finance2";
 
-import { calculateSeasonality, formatDate } from "./utils";
 import { LOOKBACK_YEARS } from "@/app/constants";
+import { HistoricalRowHistory } from "@/app/interfaces";
+
+import { calculateSeasonality, formatDate } from "./utils";
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -32,25 +34,53 @@ export async function GET(req: NextRequest) {
 
     if (timeframeType === "weekly" || !timeframeType) {
       const timeframe = "weekly";
-      const weeklyResult = await yahooFinance.historical(ticker, {
+      const weeklyResult = await yahooFinance.chart(ticker, {
         ...options,
         interval: "1wk",
       });
+
+      const quotes = weeklyResult.quotes
+        .map((quote) => ({
+          ...quote,
+          open: quote.open || null,
+          high: quote.high || null,
+          low: quote.low || null,
+          close: quote.close || null,
+          volume: quote.volume || null,
+        }))
+        .filter(
+          (dailyQuote) => dailyQuote.low !== null || dailyQuote.high !== null
+        ) as HistoricalRowHistory[];
+
       results.push({
         timeframe,
-        results: calculateSeasonality(timeframe, weeklyResult, years),
+        results: calculateSeasonality(timeframe, quotes, years),
       });
     }
 
     if (timeframeType === "monthly" || !timeframeType) {
       const timeframe = "monthly";
-      const monthlyResult = await yahooFinance.historical(ticker, {
+      const monthlyResult = await yahooFinance.chart(ticker, {
         ...options,
         interval: "1mo",
       });
+
+      const quotes = monthlyResult.quotes
+        .map((quote) => ({
+          ...quote,
+          open: quote.open || null,
+          high: quote.high || null,
+          low: quote.low || null,
+          close: quote.close || null,
+          volume: quote.volume || null,
+        }))
+        .filter(
+          (dailyQuote) => dailyQuote.low !== null || dailyQuote.high !== null
+        ) as HistoricalRowHistory[];
+
       results.push({
         timeframe,
-        results: calculateSeasonality(timeframe, monthlyResult, years),
+        results: calculateSeasonality(timeframe, quotes, years),
       });
     }
 


### PR DESCRIPTION
The yahoo-finance2 api is throwing a 500. It looks like the historical method now needs authentication. This change uses the chart method instead.